### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config.yaml
 /onelogin-auth-*
 .DS_Store
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "login",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "console": "integratedTerminal",
+            "args": ["login"],
+            "envFile": "${workspaceFolder}/.env"
+        },
+        {
+            "name": "list",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "console": "integratedTerminal",
+            "args": ["list"]
+        }
+    ]
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,7 +18,7 @@ var listCmd = &cobra.Command{
 
 		fmt.Println("Accounts:")
 		for k, v := range config.Accounts {
-			fmt.Printf("[%d] %s\n", k, v)
+			fmt.Printf("[%d] %s\n", k, v.Name)
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,9 +9,16 @@ import (
 
 type Config struct {
 	Onelogin      OneLoginConf
-	Accounts      []Account `yaml:"accounts"`
-	Roles         []string  `yaml:"roles"`
-	DefaultRegion string    `yaml:"defaultRegion"`
+	Credentials   Credentials `yaml:"credentials"`
+	Accounts      []Account   `yaml:"accounts"`
+	Roles         []string    `yaml:"roles"`
+	DefaultRegion string      `yaml:"defaultRegion"`
+}
+
+type Credentials struct {
+	Email    string `yaml:"email"`
+	Password string `yaml:"password"`
+	OTP      string `yaml:"otp"`
 }
 
 type OneLoginConf struct {
@@ -58,6 +65,10 @@ func LoadConfig(path string) (config Config, err error) {
 	if err != nil {
 		return
 	}
+
+	viper.BindEnv("credentials.email", "EMAIL")
+	viper.BindEnv("credentials.password", "PASSWORD")
+	viper.BindEnv("credentials.otp", "OTP")
 
 	err = viper.Unmarshal(&config)
 	return

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -11,3 +11,16 @@ roles:
   - iam-role-1 # role that is configured in onelogin and IAM to use with the onelogin identity provider
   - iam-role-2
 defaultRegion: us-east-1
+
+# Credentials can be specified in the YAML config file, but it is not recommended
+# because it will store the credentials in plain text on your disk.
+# It is better to use the environment variables EMAIL, PASSWORD and OTP.
+credentials:
+  # it can be overridden by the EMAIL environment variable
+  email: email of user to use for authentication
+  # it makes no sense to use this option in the YAML config file,
+  # but it can be overridden by the PASSWORD environment variable
+  password: password of user to use for authentication
+  # it makes no sense to use this option in the YAML config file,
+  # but it can be overridden by the OTP environment variable
+  otp: otpToken of user to use for authentication

--- a/utils/prompt.go
+++ b/utils/prompt.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"fmt"
-	"github.com/manifoldco/promptui"
 	"log"
 	"strconv"
+
+	"github.com/manifoldco/promptui"
 )
 
 func PromptForInt(label string) (*int, error) {
@@ -15,7 +16,7 @@ func PromptForInt(label string) (*int, error) {
 	}
 
 	prompt := promptui.Prompt{
-		Label:    label + ":",
+		Label:    label,
 		Validate: validate,
 	}
 
@@ -43,7 +44,7 @@ func PromptForString(label string) (string, error) {
 	}
 
 	prompt := promptui.Prompt{
-		Label:    label + ":",
+		Label:    label,
 		Validate: validate,
 	}
 
@@ -67,7 +68,7 @@ func PromptForSecretString(label string) (string, error) {
 	}
 
 	prompt := promptui.Prompt{
-		Label:    label + ":",
+		Label:    label,
 		Validate: validate,
 		Mask:     rune('*'),
 	}
@@ -82,10 +83,14 @@ func PromptForSecretString(label string) (string, error) {
 	return result, nil
 }
 
-func PromptSelect(label string, options []string) (string, error) {
+func PromptSelect(label string, options []string, skipSingleChoice bool) (string, error) {
+
+	if skipSingleChoice && len(options) == 1 {
+		return options[0], nil
+	}
 
 	prompt := promptui.Select{
-		Label: label + ":",
+		Label: label,
 		Items: options,
 	}
 


### PR DESCRIPTION
## Allow to pass the email, password and OTP response through the environment variables

Now you can run:

```shell
EMAIL=root@example.com PASSWORD=123 OTP=123456 onelogin-auth-cli login
```

It allows to integrate with external password vaults in order to auto-fill the credentials.

## Do not ask for the MFA device if there is only one choice

If the SamlAssertion returns only one device in Devices list, use it without prompting.

## `list` command: improved output

Instead of dumping the whole account object, it just prints its name

## UI: fixed double colon ("::") in all prompts

Now instead of:

```
Email::
```

The prompt looks like:

```
Email:
```

## Dev: added a `launch.json` file for development in VSCode

